### PR TITLE
Enable code ownership for Turner and Gabriel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# This file documents code ownership. Code must pass GitHub review from the following
+# users in order to merge into master.
+# First argument indicates directory (* for "all").
+# Second argument indicates GitHub user.
+
+* @gabrielestes
+* @TurnerMooreDavis


### PR DESCRIPTION
Creates a hidden directory and file to designate code ownership. This guards against accidental or malicious force pushes to master.

How it works: read documentation in the CODEOWNERS file.