### PR TITLE
[B5] Add v360 model

### DIFF
--- a/app/models/v360.rb
+++ b/app/models/v360.rb
@@ -1,4 +1,6 @@
 class V360 < ApplicationRecord
-  belongs_to :client, belongs_to :coach, has_one :virtualform, formable: true
+  belongs_to :client
+  belongs_to :coach
+  has_one :virtualform, as: :formable
   # has_many :invitations
 end

--- a/app/models/v360.rb
+++ b/app/models/v360.rb
@@ -1,0 +1,4 @@
+class V360 < ApplicationRecord
+  belongs_to :client, belongs_to :coach, has_one :virtualform, formable: true
+  # has_many :invitations
+end

--- a/db/migrate/20180106213806_create_v360s.rb
+++ b/db/migrate/20180106213806_create_v360s.rb
@@ -1,0 +1,8 @@
+class CreateV360s < ActiveRecord::Migration[5.1]
+  def change
+    create_table :v360s do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180106214639_add_i_ds_to_v360.rb
+++ b/db/migrate/20180106214639_add_i_ds_to_v360.rb
@@ -1,0 +1,7 @@
+class AddIDsToV360 < ActiveRecord::Migration[5.1]
+  def change
+    add_column :v360s, :client_id, :integer
+    add_column :v360s, :coach_id, :integer
+    add_column :v360s, :formable_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171202224647) do
+ActiveRecord::Schema.define(version: 20180106214639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,14 @@ ActiveRecord::Schema.define(version: 20171202224647) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["virtualform_id"], name: "index_questions_on_virtualform_id"
+  end
+
+  create_table "v360s", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "client_id"
+    t.integer "coach_id"
+    t.integer "formable_id"
   end
 
   create_table "virtualforms", force: :cascade do |t|

--- a/spec/models/v360_spec.rb
+++ b/spec/models/v360_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe V360, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
1. Added the V360 model.
2. Created a column for `client_id`, `coach_id`, and `formable_id`.
3. Verified the creation of a V360. It can't be created without a client _and_ coach id.
4. Ran migrations to update `schema.rb`.



